### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Latest Version](https://pypip.in/version/openwrt-remote-manager/badge.svg?text=pypi&style=flat)](https://pypi.python.org/pypi/openwrt-remote-manager/)
+[![Latest Version](https://img.shields.io/pypi/v/openwrt-remote-manager.svg?label=pypi&style=flat)](https://pypi.python.org/pypi/openwrt-remote-manager/)
 
 # OpenWRT Remote Manager #
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20openwrt-remote-manager))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `openwrt-remote-manager`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.